### PR TITLE
fix broken dependency for WorldEdit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         </repository>
         <repository>
             <id>sk89q-repo</id>
-            <url>http://maven.sk89q.com/repo/</url>
+            <url>https://maven.enginehub.org/repo/</url>
         </repository>
         <repository>
             <id>kitteh-repo</id>


### PR DESCRIPTION
I wasn't able to compile the jar for this plugin since the old WorldEdit dependency uses HTTP instead of HTTPS.

This new repository is not blacklisted, which allows for the plugin to be compiled

Original Error Message:

[ERROR] Failed to execute goal on project logblock: Could not resolve dependencies for project de.diddiz:logblock:jar:1.11-SNAPSHOT: Failed to collect dependencies at com.sk89q:worldedit:jar:6.0.0-SNAPSHOT: Failed to read artifact d
escriptor for com.sk89q:worldedit:jar:6.0.0-SNAPSHOT: The following artifacts could not be resolved: com.sk89q:worldedit:pom:6.0.0-SNAPSHOT (absent): Could not transfer artifact com.sk89q:worldedit:pom:6.0.0-SNAPSHOT from/to maven-d
efault-http-blocker (http://0.0.0.0/): Blocked mirror for repositories: [repobo-snap (http://repo.bukkit.org/content/groups/public, default, releases+snapshots), sk89q-repo (http://maven.sk89q.com/repo/, default, releases+snapshots)
, kitteh-repo (http://repo.kitteh.org/content/groups/public, default, releases+snapshots)] -> [Help 1]